### PR TITLE
Fix reference to old license filename

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license_file = LICENSE
+license_file = LICENSE.md
 name = django-slick-reporting
 version = attr: slick_reporting.__version__
 author = Ra Systems


### PR DESCRIPTION
The file LICENSE was renamed to LICENSE.md in a recent commit. This caused building from PyPI to break even though installation seemed to work.