### PR TITLE
Fix spelling of `cirspy`

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,10 +10,10 @@ Installation
 
 To install django-slick-reporting:
 
-1.  Install with pip: ``pip install django-slick-reporting``.
-2.  Add ``'slick_reporting'`` to ``INSTALLED_APPS``.
-3. For the shipped in View, add ``'cirspy_forms'`` to ``INSTALLED_APPS``and add `CRISPY_TEMPLATE_PACK = 'bootstrap4'`
-   to your `settings.py`
+1.  Install with pip: `pip install django-slick-reporting`.
+2.  Add ``slick_reporting'`` to ``INSTALLED_APPS``.
+3. For the shipped in View, add ``'crispy_forms'`` to ``INSTALLED_APPS`` and add ``CRISPY_TEMPLATE_PACK = 'bootstrap4'``
+   to your ``settings.py``
 
 
 Quickstart


### PR DESCRIPTION
Typo in documentation - caught an error on copy/paste when attempting to install. 