### PR TITLE
Add datepicker initialization function call

### DIFF
--- a/slick_reporting/templates/slick_reporting/simple_report.html
+++ b/slick_reporting/templates/slick_reporting/simple_report.html
@@ -172,6 +172,7 @@
 
             $('table').DataTable();
             $('.nav-charts').find('a:first').trigger('click');
+            setDatePicker();
 
 
         })


### PR DESCRIPTION
This PR fixes a minor omission:

Wrapper function `setDatePicker();` is never executed in initialization script.