### PR TITLE
Ability to hide columns

### DIFF
--- a/slick_reporting/generator.py
+++ b/slick_reporting/generator.py
@@ -114,7 +114,7 @@ class ReportGenerator(object):
 
     def __init__(self, report_model=None, main_queryset=None, start_date=None, end_date=None, date_field=None,
                  q_filters=None, kwargs_filters=None,
-                 group_by=None, columns=None,
+                 group_by=None, columns=None, hidden_columns=None,
                  time_series_pattern=None, time_series_columns=None, time_series_custom_dates=None,
                  crosstab_model=None, crosstab_columns=None, crosstab_ids=None, crosstab_compute_reminder=None,
                  swap_sign=False, show_empty_records=None,
@@ -176,6 +176,7 @@ class ReportGenerator(object):
         main_queryset = main_queryset.order_by()
 
         self.columns = columns or self.columns or []
+        self.hidden_columns = hidden_columns or self.hidden_columns or []        
         self.group_by = group_by or self.group_by
 
         self.time_series_pattern = self.time_series_pattern or time_series_pattern

--- a/slick_reporting/generator.py
+++ b/slick_reporting/generator.py
@@ -58,14 +58,14 @@ class ReportGenerator(object):
        Same is true with __crosstab__ 
      """
      
-     hidden_columns = None
-     """
-     A list of columns that are hidden on the table view
+    hidden_columns = None
+    """
+    A list of columns that are hidden on the table view
      
-     This is useful when you need a column's data to format another, but don't need to show that to the user, or to merge column data into one
+    This is useful when you need a column's data to format another, but don't need to show that to the user, or to merge column data into one
      
-     Example: columns = ['product_id']
-     """
+    Example: columns = ['product_id']
+    """
 
     time_series_pattern = ''
     """

--- a/slick_reporting/generator.py
+++ b/slick_reporting/generator.py
@@ -57,6 +57,15 @@ class ReportGenerator(object):
        columns = ['product_id', '__time_series__', 'col_b']
        Same is true with __crosstab__ 
      """
+     
+     hidden_columns = None
+     """
+     A list of columns that are hidden on the table view
+     
+     This is useful when you need a column's data to format another, but don't need to show that to the user, or to merge column data into one
+     
+     Example: columns = ['product_id']
+     """
 
     time_series_pattern = ''
     """

--- a/slick_reporting/templates/slick_reporting/table.html
+++ b/slick_reporting/templates/slick_reporting/table.html
@@ -3,7 +3,9 @@
     <thead>
 <tr>
     {% for column in table.columns %}
-        <th>{{ column.verbose_name }}</th>
+        {% if column.visible %}
+            <th>{{ column.verbose_name }}</th>
+        {% endif %}
 
     {% endfor %}
 </tr>
@@ -12,8 +14,10 @@
 {% for row in table.data %}
     <tr class="{% cycle 'row1' 'row2' %}">
     {% for column in table.columns %}
-        <td>{% get_data row column %}</td>
-        {% endfor %}
+        {% if column.visible %}
+            <td>{% get_data row column %}</td>
+        {% endif %}
+    {% endfor %}
     </tr>
 {% endfor %}
 </tbody>

--- a/slick_reporting/views.py
+++ b/slick_reporting/views.py
@@ -16,6 +16,7 @@ from .generator import ReportGenerator
 class SlickReportViewBase(FormView):
     group_by = None
     columns = None
+    hidden_columns = None
 
     report_title = ''
     time_series_pattern = ''
@@ -134,6 +135,7 @@ class SlickReportViewBase(FormView):
                                            print_flag=for_print,
                                            limit_records=self.limit_records, swap_sign=self.swap_sign,
                                            columns=self.columns,
+                                           hidden_columns=self.hidden_columns,
                                            group_by=self.group_by,
                                            time_series_pattern=self.time_series_pattern,
                                            time_series_columns=self.time_series_columns,
@@ -168,10 +170,11 @@ class SlickReportViewBase(FormView):
                 'name': col['name'],
                 'computation_field': col.get('original_name', ''),
                 'verbose_name': col['verbose_name'],
-                'visible': col.get('visible', True),
+                'visible': col.get('visible', col['name'] not in self.hidden_columns),
                 'type': col.get('type', 'text'),
                 'is_summable': col.get('is_summable', ''),
             })
+            
         return data
 
     def get_report_results(self, for_print=False):

--- a/slick_reporting/views.py
+++ b/slick_reporting/views.py
@@ -164,13 +164,14 @@ class SlickReportViewBase(FormView):
         """
         # columns = report_generator.get_list_display_columns()
         data = []
+        hidden = self.hidden_columns or []
 
         for col in columns:
             data.append({
                 'name': col['name'],
                 'computation_field': col.get('original_name', ''),
                 'verbose_name': col['verbose_name'],
-                'visible': col.get('visible', col['name'] not in self.hidden_columns),
+                'visible': col.get('visible', col['name'] not in hidden),
                 'type': col.get('type', 'text'),
                 'is_summable': col.get('is_summable', ''),
             })


### PR DESCRIPTION
Hi,

I needed to hide a columns as I was using [django-money](https://github.com/django-money/django-money) and need the field_currency value (which it create for a MoneyField (which is a DecimalField + CharField with the currency type) to be able to do this:

    def format_row(self, row_obj):
        row_obj['value'] = Money(row_obj['value'], row_obj['value_currency'])

As I found no option to hide the column I added some code to make this possible.

Please review it and request changes if necessary.