### PR TITLE
Fix for Django 3.2

### DIFF
--- a/slick_reporting/apps.py
+++ b/slick_reporting/apps.py
@@ -3,7 +3,7 @@ from django import apps
 
 
 class ReportAppConfig(apps.AppConfig):
-    label = 'Slick Reporting'
+    verbose_name = 'Slick Reporting'
     name = 'slick_reporting'
 
     def ready(self):

--- a/slick_reporting/fields.py
+++ b/slick_reporting/fields.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.db.models import Sum
 from django.template.defaultfilters import date as date_filter
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .helpers import get_calculation_annotation
 from .registry import field_registry


### PR DESCRIPTION
Two minor fixes:
- use `verbose_name` instead of `label` in app config (breaking)
- replace deprecated `ugettext_lazy` (deprecation)