### PR TITLE
Support overriding initial date range via SlickReportView.get_initial().

### DIFF
--- a/slick_reporting/form_factory.py
+++ b/slick_reporting/form_factory.py
@@ -96,7 +96,8 @@ def _default_foreign_key_widget(f_field):
     return {'form_class': forms.ModelMultipleChoiceField, 'required': False, }
 
 
-def report_form_factory(model, crosstab_model=None, display_compute_reminder=True, fkeys_filter_func=None,
+def report_form_factory(model, crosstab_model=None, start_date=None, end_date=None,
+                        display_compute_reminder=True, fkeys_filter_func=None,
                         foreign_key_widget_func=None, excluded_fields=None):
     """
     Create a Report Form based on the report_model passed by
@@ -127,11 +128,11 @@ def report_form_factory(model, crosstab_model=None, display_compute_reminder=Tru
     fields = OrderedDict()
 
     fields['start_date'] = forms.DateTimeField(required=False, label=_('From date'),
-                                               initial=app_settings.SLICK_REPORTING_DEFAULT_START_DATE,
+                                               initial=start_date or app_settings.SLICK_REPORTING_DEFAULT_START_DATE,
                                                widget=forms.DateTimeInput(attrs={'autocomplete': "off"}))
 
     fields['end_date'] = forms.DateTimeField(required=False, label=_('To  date'),
-                                             initial=app_settings.SLICK_REPORTING_DEFAULT_END_DATE,
+                                             initial=end_date or app_settings.SLICK_REPORTING_DEFAULT_END_DATE,
                                              widget=forms.DateTimeInput(attrs={'autocomplete': "off"}))
 
     for name, f_field in fkeys_map.items():

--- a/slick_reporting/templates/slick_reporting/simple_report.html
+++ b/slick_reporting/templates/slick_reporting/simple_report.html
@@ -170,11 +170,14 @@
 
             }
 
-            $('table').DataTable();
+            try {
+              $('table').DataTable();
+            } catch {
+              // Ignore if the DataTables library is not available.
+            }
+            
             $('.nav-charts').find('a:first').trigger('click');
             setDatePicker();
-
-
         })
     </script>
 

--- a/slick_reporting/views.py
+++ b/slick_reporting/views.py
@@ -90,7 +90,11 @@ class SlickReportViewBase(FormView):
         Automatically instantiate a form based on details provided
         :return:
         """
-        return self.form_class or report_form_factory(self.get_report_model(), crosstab_model=self.crosstab_model,
+        initial = self.get_initial()
+        return self.form_class or report_form_factory(self.get_report_model(),
+                                                      start_date=initial.get('start_date'),
+                                                      end_date=initial.get('end_date'),
+                                                      crosstab_model=self.crosstab_model,
                                                       display_compute_reminder=self.crosstab_compute_reminder,
                                                       excluded_fields=self.excluded_fields)
 
@@ -125,9 +129,11 @@ class SlickReportViewBase(FormView):
         crosstab_compute_reminder = self.form.get_crosstab_compute_reminder() if self.request.GET or self.request.POST \
             else self.crosstab_compute_reminder
 
+        initial = self.get_initial()
+
         return self.report_generator_class(self.get_report_model(),
-                                           start_date=self.form.cleaned_data['start_date'],
-                                           end_date=self.form.cleaned_data['end_date'],
+                                           start_date=self.form.cleaned_data['start_date'] or initial['start_date'],
+                                           end_date=self.form.cleaned_data['end_date'] or initial['end_date'],
                                            q_filters=q_filters,
                                            kwargs_filters=kw_filters,
                                            date_field=self.date_field,
@@ -210,11 +216,10 @@ class SlickReportViewBase(FormView):
         return cls.__name__.lower()
 
     def get_initial(self):
-        # todo revise why not actually displaying datetime on screen
-        return {
-            'start_date': SLICK_REPORTING_DEFAULT_START_DATE,
-            'end_date': SLICK_REPORTING_DEFAULT_END_DATE
-        }
+        initial = super().get_initial()
+        initial['start_date'] = SLICK_REPORTING_DEFAULT_START_DATE
+        initial['end_date'] = SLICK_REPORTING_DEFAULT_END_DATE
+        return initial
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
In a `SlickReportView`, you can now do:

```
    def get_initial(self):
        initial = super().get_initial()
        initial['start_date'] = get_n_months_ago(3)
        initial['end_date'] = get_first_of_next_month()
        return initial
```

(for example, if those two `get_`... functions are defined elsewhere). This is useful when a specific date range is a characteristic of a given view, and the user won't often need to change it. It addresses the `# todo` comment in `get_initial()`.